### PR TITLE
Added: 1. Support for signal to cancel API requests

### DIFF
--- a/src/api/crudOperations.js
+++ b/src/api/crudOperations.js
@@ -105,6 +105,7 @@ const getSingleEntity = async (endpoint, id, options) => {
 const getMultipleEntities = async (
   endpoint,
   options,
+  signal,
   responseField = endpoint
 ) => {
   const searchParams = getUrlSearchParamsFromOptions(options)
@@ -121,7 +122,9 @@ const getMultipleEntities = async (
   }
 
   try {
-    const response = await baseApi.get(url)
+    // signal is a part of abort-controller
+    // which helps to cancel the API request
+    const response = await baseApi.get(url, { signal })
     return ResponseParser.getList(response, responseField)
   } catch (error) {
     return handleError(error)
@@ -285,8 +288,8 @@ export const getItemByEndpoint = (endpoint, options) => {
  * @param {any | string} options
  * @returns
  */
-export const getItems = (endpoint, options) => {
-  return getMultipleEntities(endpoint, options)
+export const getItems = (endpoint, options, signal) => {
+  return getMultipleEntities(endpoint, options, signal)
 }
 
 /**

--- a/src/api/services/v3/cmp/JobsService.js
+++ b/src/api/services/v3/cmp/JobsService.js
@@ -8,7 +8,7 @@ export default {
    * @param options anything parsable by URLSearchParams. See useful options here https://docs.cloudbolt.io/articles/#!cloudbolt-latest-docs/api-conventions/a/h2__904191799
    * @returns
    */
-  list: (options) => crud.getItems(URL, options),
+  list: (options, signal) => crud.getItems(URL, options, signal),
 
   /**
    * Retrieve an existing job


### PR DESCRIPTION
[Jira](https://cloudbolt.atlassian.net/browse/ENG-22545) 
It includes a feature of cancelling API requests as and when needed from the microfront-ends
Here, we are utilising the abort-controller which provides signal, one (created) at the UI side and one (feeded) at the API side
[AbortController](https://axios-http.com/docs/cancellation)