### PR TITLE
ENG-25279-Inbound webhook support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudbolt/js-sdk",
-  "version": "0.6.0",
+  "version": "0.6.1-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudbolt/js-sdk",
-      "version": "0.6.0",
+      "version": "0.6.1-beta.0",
       "dependencies": {
         "axios": "^0.27.2",
         "ramda": "^0.28.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudbolt/js-sdk",
-  "version": "0.6.1-beta.0",
+  "version": "0.6.2-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudbolt/js-sdk",
-      "version": "0.6.1-beta.0",
+      "version": "0.6.2-beta.0",
       "dependencies": {
         "axios": "^0.27.2",
         "ramda": "^0.28.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudbolt/js-sdk",
-  "version": "0.6.0",
+  "version": "0.6.1-beta.0",
   "description": "CloudBolt Javascript package for interacting with the CloudBolt API",
   "scripts": {
     "husky:install": "husky install",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudbolt/js-sdk",
-  "version": "0.6.1-beta.0",
+  "version": "0.6.2-beta.0",
   "description": "CloudBolt Javascript package for interacting with the CloudBolt API",
   "scripts": {
     "husky:install": "husky install",

--- a/src/api/services/v3/cmp/InboundWebHookService.js
+++ b/src/api/services/v3/cmp/InboundWebHookService.js
@@ -1,0 +1,48 @@
+import crud from '../../../crudOperations'
+
+const URL = 'v3/cmp/inboundWebHooks'
+
+export default {
+  /**
+   * Retrieve a list of existing Inbound Web Hooks
+   * @param options anything parsable by URLSearchParams. See useful options here https://docs.cloudbolt.io/articles/#!cloudbolt-latest-docs/api-conventions/a/h2__904191799
+   * @returns {Promise} resolves with a list of existing Inbound Web Hooks
+   */
+  list: (options) => crud.getItems(URL, options),
+
+  /**
+   * Retrieve an existing Inbound Web Hook by id
+   * @param {string} id or global_id
+   * @returns {Promise} resolves with a cloudbolt API Response object of the Inbound Web Hook object
+   */
+  get: (id) => crud.getItemById(URL, id),
+
+  /**
+   * Export an existing Inbound Web Hook as a zipfile for a given id
+   * @param {string} id or global_id
+   * @param {object} InboundWebHookOptions
+   * @param {string} [InboundWebHookOptions.password] password to the zip if it's password-protected
+   * @param {boolean} [InboundWebHookOptions.instanceSpecificInfo=false] determines if the Inbound Web Hook should include info specific to the CloudBolt instance
+   * @returns {Promise} resolves with a cloudbolt API Export Inbound Web Hook Success Response and zip file
+   */
+  export: (id, InboundWebHookOptions) =>
+    crud.downloadWithPayload(URL, id, InboundWebHookOptions),
+
+  /**
+   * Run an Inbound Web Hook via POST
+   * @param {string} id or global_id
+   * @param {object} payload Inbound Web Hook object definition
+   * @returns {Promise} resolves with a cloudbolt API Run Inbound Web Hook Success Response
+   */
+  runPost: (id, payload) =>
+    crud.postItem(`${URL}/${id}/run`, payload),
+
+  /**
+   * Run an Inbound Web Hook via GET
+   * @param {string} id or global_id
+   * @param {object} options querystring name value pairs to be used as Action input values
+   * @returns {Promise} resolves with a cloudbolt API Run Inbound Web Hook Success Response
+   */
+  runGet: (id, options) =>
+    crud.getItemByEndpoint(`${URL}/${id}/run`, options),
+}

--- a/src/api/services/v3/cmp/InboundWebHookService.test.js
+++ b/src/api/services/v3/cmp/InboundWebHookService.test.js
@@ -1,0 +1,80 @@
+import { baseApi } from '../../../baseApi'
+import InboundWebHook from './InboundWebHookService'
+
+test('list calls the correct endpoint', async () => {
+  const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({
+    data: { hello: 'world' }
+  })
+  await InboundWebHook.list()
+  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/inboundWebHooks/')
+})
+
+test('get calls the correct endpoint', async () => {
+  const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({
+    data: { hello: 'world' }
+  })
+  await InboundWebHook.get('inboundWebHook-id')
+  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/inboundWebHooks/inboundWebHook-id/')
+})
+
+test('export calls the correct endpoint', async () => {
+  const mockFn = jest.spyOn(baseApi, 'post').mockResolvedValue({
+    data: { hello: 'world' },
+    headers: {
+      'content-disposition': 'attachment; filename=action.zip'
+    }
+  })
+
+  await InboundWebHook.export('inboundWebHook-id')
+  expect(mockFn).toHaveBeenCalledWith(
+    '/v3/cmp/inboundWebHooks/inboundWebHook-id/export/',
+    {},
+    { responseType: 'blob' }
+  )
+})
+
+test('export with options calls the correct endpoint', async () => {
+  const mockFn = jest.spyOn(baseApi, 'post').mockResolvedValue({
+    data: { hello: 'world' },
+    headers: {
+      'content-disposition': 'attachment; filename=action.zip'
+    }
+  })
+  const mockinboundWebHookOptions = {
+    password: 'worldinboundWebHook',
+    instanceSpecificInfo: true
+  }
+  await InboundWebHook.export('inboundWebHook-id', mockinboundWebHookOptions)
+  expect(mockFn).toHaveBeenCalledWith(
+    '/v3/cmp/inboundWebHooks/inboundWebHook-id/export/',
+    mockinboundWebHookOptions,
+    { responseType: 'blob' }
+  )
+})
+
+test('run calls the correct endpoint', async () => {
+  const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({
+    data: { hello: 'world' }
+  })
+  const mockParameters = {
+      param1: 'value1'
+  }   
+  await InboundWebHook.runGet('inboundWebHook-id', mockParameters)
+  expect(mockFn).toHaveBeenCalledWith(
+    '/v3/cmp/inboundWebHooks/inboundWebHook-id/run/?param1=value1',
+  )
+})
+
+test('run calls the correct endpoint', async () => {
+  const mockFn = jest.spyOn(baseApi, 'post').mockResolvedValue({
+    data: { hello: 'world' }
+  })
+  const mockPayload = {
+      param1: 'value1'
+  }
+  await InboundWebHook.runPost('inboundWebHook-id', mockPayload)
+  expect(mockFn).toHaveBeenCalledWith(
+    '/v3/cmp/inboundWebHooks/inboundWebHook-id/run/',
+    mockPayload
+  )
+})

--- a/src/api/services/v3/cmp/index.js
+++ b/src/api/services/v3/cmp/index.js
@@ -14,6 +14,7 @@ import EnvironmentsService from './EnvironmentsService'
 import EulaService from './EulaService'
 import GroupsService from './GroupsService'
 import HistoriesService from './HistoriesService'
+import InboundWebHookService from './InboundWebHookService'
 import JobsService from './JobsService'
 import LicensingService from './LicensingService'
 import LoggingService from './LoggingService'
@@ -60,6 +61,7 @@ export default {
   eula: EulaService,
   groups: GroupsService,
   histories: HistoriesService,
+  inboundWebHooks: InboundWebHookService,
   jobs: JobsService,
   licensing: LicensingService,
   logging: LoggingService,

--- a/src/api/services/v3/cmp/index.test.js
+++ b/src/api/services/v3/cmp/index.test.js
@@ -23,6 +23,7 @@ const services = [
   'eula',
   'groups',
   'histories',
+  'inboundWebHooks',
   'jobs',
   'licensing',
   'licensing',


### PR DESCRIPTION
For [Ticket ENG-25279 Add examples of calling the CB API to the CB Applet ](https://cloudbolt.atlassian.net/browse/ENG-25279)
Written by @bernardthered  
