### PR TITLE
Feature/cmp 32 applet update base api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudbolt/js-sdk",
-  "version": "0.6.3",
+  "version": "0.6.4-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudbolt/js-sdk",
-      "version": "0.6.3",
+      "version": "0.6.4-beta.0",
       "dependencies": {
         "axios": "^0.27.2",
         "ramda": "^0.28.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudbolt/js-sdk",
-  "version": "0.6.4-beta.0",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudbolt/js-sdk",
-      "version": "0.6.4-beta.0",
+      "version": "0.6.3",
       "dependencies": {
         "axios": "^0.27.2",
         "ramda": "^0.28.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudbolt/js-sdk",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudbolt/js-sdk",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dependencies": {
         "axios": "^0.27.2",
         "ramda": "^0.28.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudbolt/js-sdk",
-  "version": "0.6.4-beta.0",
+  "version": "0.6.3",
   "description": "CloudBolt Javascript package for interacting with the CloudBolt API",
   "scripts": {
     "husky:install": "husky install",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudbolt/js-sdk",
-  "version": "0.6.3",
+  "version": "0.6.4-beta.0",
   "description": "CloudBolt Javascript package for interacting with the CloudBolt API",
   "scripts": {
     "husky:install": "husky install",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudbolt/js-sdk",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "CloudBolt Javascript package for interacting with the CloudBolt API",
   "scripts": {
     "husky:install": "husky install",

--- a/src/api/baseApi.js
+++ b/src/api/baseApi.js
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-const BASE_URL = '/api'
+const BASE_URL = '/'
 
 let abortController
 

--- a/src/api/services/v3/cmp/AlertsService.js
+++ b/src/api/services/v3/cmp/AlertsService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/alerts'
+const URL = 'api/v3/cmp/alerts'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/AlertsService.test.js
+++ b/src/api/services/v3/cmp/AlertsService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await AlertsService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/alerts/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/alerts/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -14,7 +14,7 @@ test('get calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await AlertsService.get('alert-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/alerts/alert-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/alerts/alert-id/')
 })
 
 test('create calls the correct endpoint', async () => {
@@ -26,7 +26,7 @@ test('create calls the correct endpoint', async () => {
     name: 'worldAlert'
   }
   await AlertsService.create(mockAlert)
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/alerts/', mockAlert)
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/alerts/', mockAlert)
 })
 
 test('update calls the correct endpoint', async () => {
@@ -35,7 +35,7 @@ test('update calls the correct endpoint', async () => {
   })
   const mockAlert = { hello: 'world' }
   await AlertsService.update('alert-id', mockAlert)
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/alerts/alert-id/', mockAlert)
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/alerts/alert-id/', mockAlert)
 })
 
 test('replace calls the correct endpoint', async () => {
@@ -44,11 +44,11 @@ test('replace calls the correct endpoint', async () => {
   })
   const mockAlert = { hello: 'world' }
   await AlertsService.replace('alert-id', mockAlert)
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/alerts/alert-id/', mockAlert)
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/alerts/alert-id/', mockAlert)
 })
 
 test('delete calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
   await AlertsService.delete('alert-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/alerts/alert-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/alerts/alert-id/')
 })

--- a/src/api/services/v3/cmp/ApiTokenService.js
+++ b/src/api/services/v3/cmp/ApiTokenService.js
@@ -37,15 +37,19 @@ export default {
    */
   obtainToken: async (username, password) => {
     const requestBody = createTokenRequestBody(username, password)
-    let response = await crud.createNewItem('v3/cmp/apiToken', requestBody)
+    let response = await crud.createNewItem('api/v3/cmp/apiToken', requestBody)
     const token = response.token
     return token
   },
 
   obtainTokenWithSessionCookie: async () => {
-    let response = await baseApi.post('v3/cmp/apiToken/', {}, {withCredentials: true})
+    let response = await baseApi.post(
+      'api/v3/cmp/apiToken/',
+      {},
+      { withCredentials: true }
+    )
     const token = response?.data?.token
-    if(token) {
+    if (token) {
       return token
     } else {
       throw new Error('Invalid response from API')
@@ -57,7 +61,7 @@ export default {
    * @returns {string | undefined} - Returns the api token or undefined
    */
   refreshToken: async () => {
-    let response = await crud.createNewItem('v3/cmp/apiTokenRefresh', null)
+    let response = await crud.createNewItem('api/v3/cmp/apiTokenRefresh', null)
     if (response?.token) {
       return response?.token
     }

--- a/src/api/services/v3/cmp/ApiTokenService.test.js
+++ b/src/api/services/v3/cmp/ApiTokenService.test.js
@@ -2,8 +2,8 @@ import { baseApi } from '../../../baseApi'
 import crud from '../../../crudOperations'
 import ApiTokenService from './ApiTokenService'
 
-const LOGIN_URL = 'v3/cmp/apiToken'
-const REFRESH_URL = 'v3/cmp/apiTokenRefresh'
+const LOGIN_URL = 'api/v3/cmp/apiToken'
+const REFRESH_URL = 'api/v3/cmp/apiTokenRefresh'
 
 describe('ApiTokenService', () => {
   it('obtainToken calls API and returns a token', async () => {
@@ -43,13 +43,13 @@ describe('ApiTokenService', () => {
     expect(response).toBe('token')
   })
 
-  it('obtainTokenWithSessionCookie uses withCredentials to pass cookie and no post body to API', async() => {
-    jest.spyOn(baseApi, 'post').mockResolvedValue({ data: {token: 'token' }})
+  it('obtainTokenWithSessionCookie uses withCredentials to pass cookie and no post body to API', async () => {
+    jest.spyOn(baseApi, 'post').mockResolvedValue({ data: { token: 'token' } })
 
     const response = await ApiTokenService.obtainTokenWithSessionCookie()
 
     expect(baseApi.post).toBeCalledWith(
-      LOGIN_URL+'/',
+      LOGIN_URL + '/',
       {},
       { withCredentials: true }
     )

--- a/src/api/services/v3/cmp/AppletsService.js
+++ b/src/api/services/v3/cmp/AppletsService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/applets'
+const URL = 'api/v3/cmp/applets'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/BlueprintCategoriesService.js
+++ b/src/api/services/v3/cmp/BlueprintCategoriesService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/blueprintCategories'
+const URL = 'api/v3/cmp/blueprintCategories'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/BlueprintCategoriesService.test.js
+++ b/src/api/services/v3/cmp/BlueprintCategoriesService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await BlueprintCategoriesService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/blueprintCategories/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/blueprintCategories/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -15,7 +15,7 @@ test('get calls the correct endpoint', async () => {
   })
   await BlueprintCategoriesService.get('blueprintCategory-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/blueprintCategories/blueprintCategory-id/'
+    '/api/v3/cmp/blueprintCategories/blueprintCategory-id/'
   )
 })
 
@@ -29,7 +29,7 @@ test('create calls the correct endpoint', async () => {
   }
   await BlueprintCategoriesService.create(mockBlueprintCategory)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/blueprintCategories/',
+    '/api/v3/cmp/blueprintCategories/',
     mockBlueprintCategory
   )
 })
@@ -44,7 +44,7 @@ test('update calls the correct endpoint', async () => {
     mockBlueprintCategory
   )
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/blueprintCategories/blueprintCategory-id/',
+    '/api/v3/cmp/blueprintCategories/blueprintCategory-id/',
     mockBlueprintCategory
   )
 })
@@ -53,6 +53,6 @@ test('delete calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
   await BlueprintCategoriesService.delete('blueprintCategory-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/blueprintCategories/blueprintCategory-id/'
+    '/api/v3/cmp/blueprintCategories/blueprintCategory-id/'
   )
 })

--- a/src/api/services/v3/cmp/BlueprintFiltersService.js
+++ b/src/api/services/v3/cmp/BlueprintFiltersService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/blueprintFilters'
+const URL = 'api/v3/cmp/blueprintFilters'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/BlueprintFiltersService.test.js
+++ b/src/api/services/v3/cmp/BlueprintFiltersService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await BlueprintFiltersService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/blueprintFilters/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/blueprintFilters/')
 })
 
 test('list passes options correctly', async () => {
@@ -15,7 +15,7 @@ test('list passes options correctly', async () => {
   })
   await BlueprintFiltersService.list({ attributes: 'choices' })
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/blueprintFilters/?attributes=choices'
+    '/api/v3/cmp/blueprintFilters/?attributes=choices'
   )
 })
 
@@ -24,7 +24,9 @@ test('get calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await BlueprintFiltersService.get('blueprint-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/blueprintFilters/blueprint-id/')
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/blueprintFilters/blueprint-id/'
+  )
 })
 
 test('get passes options correctly', async () => {
@@ -33,6 +35,6 @@ test('get passes options correctly', async () => {
   })
   await BlueprintFiltersService.get('blueprint-id', { attributes: 'choices' })
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/blueprintFilters/blueprint-id/?attributes=choices'
+    '/api/v3/cmp/blueprintFilters/blueprint-id/?attributes=choices'
   )
 })

--- a/src/api/services/v3/cmp/BlueprintsService.js
+++ b/src/api/services/v3/cmp/BlueprintsService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/blueprints'
+const URL = 'api/v3/cmp/blueprints'
 
 export default {
   /**
@@ -47,7 +47,10 @@ export default {
    * @returns {Promise} resolves with a Blueprint Deployment schema object with all server-filled fields
    */
   deploymentSchema: (id, schemaInfo) =>
-    crud.createNewItem(`v3/cmp/blueprints/${id}/deploymentSchema`, schemaInfo),
+    crud.createNewItem(
+      `api/v3/cmp/blueprints/${id}/deploymentSchema`,
+      schemaInfo
+    ),
 
   /**
    * Generates and submits an Order to deploy a custom instance of the Blueprint by id
@@ -59,7 +62,7 @@ export default {
    * @returns {Promise} resolves with a Blueprint Deployment schema object with all server-filled fields
    */
   deploy: (id, customDeploy) =>
-    crud.createNewItem(`v3/cmp/blueprints/${id}/deploy`, customDeploy),
+    crud.createNewItem(`api/v3/cmp/blueprints/${id}/deploy`, customDeploy),
 
   /**
    * Generates a sample deployment payload for the given group and server item environments.
@@ -70,5 +73,5 @@ export default {
    * @returns {Promise} resolves with a Blueprint Sample Deployment Payload success response
    */
   samplePayload: (id, payloadType) =>
-    crud.createNewItem(`v3/cmp/blueprints/${id}/samplePayload`, payloadType)
+    crud.createNewItem(`api/v3/cmp/blueprints/${id}/samplePayload`, payloadType)
 }

--- a/src/api/services/v3/cmp/BlueprintsService.test.js
+++ b/src/api/services/v3/cmp/BlueprintsService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await BlueprintsService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/blueprints/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/blueprints/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -14,7 +14,7 @@ test('get calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await BlueprintsService.get('blueprint-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/blueprints/blueprint-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/blueprints/blueprint-id/')
 })
 
 test('create calls the correct endpoint', async () => {
@@ -24,7 +24,7 @@ test('create calls the correct endpoint', async () => {
   const mockBlueprintObject = { zipFile: 'world.zip' }
   await BlueprintsService.create(mockBlueprintObject)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/blueprints/',
+    '/api/v3/cmp/blueprints/',
     mockBlueprintObject
   )
 })
@@ -39,7 +39,7 @@ test('export calls the correct endpoint', async () => {
 
   await BlueprintsService.export('blueprint-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/blueprints/blueprint-id/export/',
+    '/api/v3/cmp/blueprints/blueprint-id/export/',
     {},
     { responseType: 'blob' }
   )
@@ -58,7 +58,7 @@ test('export with options calls the correct endpoint', async () => {
   }
   await BlueprintsService.export('blueprint-id', mockBlueprintObject)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/blueprints/blueprint-id/export/',
+    '/api/v3/cmp/blueprints/blueprint-id/export/',
     mockBlueprintObject,
     { responseType: 'blob' }
   )
@@ -74,7 +74,7 @@ test('deploymentSchema calls the correct endpoint', async () => {
 
   await BlueprintsService.deploymentSchema('blueprint-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/blueprints/blueprint-id/deploymentSchema/',
+    '/api/v3/cmp/blueprints/blueprint-id/deploymentSchema/',
     undefined
   )
 })
@@ -86,7 +86,7 @@ test('deploy calls the correct endpoint', async () => {
 
   await BlueprintsService.deploy('blueprint-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/blueprints/blueprint-id/deploy/',
+    '/api/v3/cmp/blueprints/blueprint-id/deploy/',
     undefined
   )
 })
@@ -100,7 +100,7 @@ test('custom deploy calls the correct endpoint', async () => {
 
   await BlueprintsService.deploy('blueprint-id', mockCustomDeploy)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/blueprints/blueprint-id/deploy/',
+    '/api/v3/cmp/blueprints/blueprint-id/deploy/',
     mockCustomDeploy
   )
 })
@@ -113,7 +113,7 @@ test('samplePayload calls the correct endpoint', async () => {
   const mockPayloadType = { order: 'world' }
   await BlueprintsService.samplePayload('blueprint-id', mockPayloadType)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/blueprints/blueprint-id/samplePayload/',
+    '/api/v3/cmp/blueprints/blueprint-id/samplePayload/',
     mockPayloadType
   )
 })

--- a/src/api/services/v3/cmp/BrandedPortalsService.js
+++ b/src/api/services/v3/cmp/BrandedPortalsService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/brandedPortals'
+const URL = 'api/v3/cmp/brandedPortals'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/BrandedPortalsService.test.js
+++ b/src/api/services/v3/cmp/BrandedPortalsService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await BrandedPortalsService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/brandedPortals/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/brandedPortals/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -15,7 +15,7 @@ test('get calls the correct endpoint', async () => {
   })
   await BrandedPortalsService.get('brandedPortal-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/brandedPortals/brandedPortal-id/'
+    '/api/v3/cmp/brandedPortals/brandedPortal-id/'
   )
 })
 
@@ -24,7 +24,9 @@ test('get current portal calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await BrandedPortalsService.getCurrentPortal()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/brandedPortals/currentPortal/')
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/brandedPortals/currentPortal/'
+  )
 })
 
 test('create calls the correct endpoint', async () => {
@@ -37,7 +39,7 @@ test('create calls the correct endpoint', async () => {
   }
   await BrandedPortalsService.create(mockBrandedPortal)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/brandedPortals/',
+    '/api/v3/cmp/brandedPortals/',
     mockBrandedPortal
   )
 })
@@ -49,7 +51,7 @@ test('update calls the correct endpoint', async () => {
   const mockBrandedPortal = { name: 'biggerWorld' }
   await BrandedPortalsService.update('brandedPortal-id', mockBrandedPortal)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/brandedPortals/brandedPortal-id/',
+    '/api/v3/cmp/brandedPortals/brandedPortal-id/',
     mockBrandedPortal
   )
 })
@@ -64,7 +66,7 @@ test('replace calls the correct endpoint', async () => {
   }
   await BrandedPortalsService.replace('brandedPortal-id', mockBrandedPortal)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/brandedPortals/brandedPortal-id/',
+    '/api/v3/cmp/brandedPortals/brandedPortal-id/',
     mockBrandedPortal
   )
 })
@@ -73,6 +75,6 @@ test('delete calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
   await BrandedPortalsService.delete('brandedPortal-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/brandedPortals/brandedPortal-id/'
+    '/api/v3/cmp/brandedPortals/brandedPortal-id/'
   )
 })

--- a/src/api/services/v3/cmp/CatalogBlueprintsService.js
+++ b/src/api/services/v3/cmp/CatalogBlueprintsService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/catalog/blueprints'
+const URL = 'api/v3/cmp/catalog/blueprints'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/CatalogBlueprintsService.test.js
+++ b/src/api/services/v3/cmp/CatalogBlueprintsService.test.js
@@ -1,18 +1,20 @@
 import { baseApi } from '../../../baseApi'
-import AppletsService from './AppletsService'
+import CatalogBlueprintsService from './CatalogBlueprintsService'
 
 test('list calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({
     data: { hello: 'world' }
   })
-  await AppletsService.list()
-  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/applets/')
+  await CatalogBlueprintsService.list()
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/catalog/blueprints/')
 })
 
 test('get calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({
     data: { hello: 'world' }
   })
-  await AppletsService.get('applet-id')
-  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/applets/applet-id/')
+  await CatalogBlueprintsService.get('blueprintCatalog-id')
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/catalog/blueprints/blueprintCatalog-id/'
+  )
 })

--- a/src/api/services/v3/cmp/CitService.js
+++ b/src/api/services/v3/cmp/CitService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/cit'
+const URL = 'api/v3/cmp/cit'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/CitService.test.js
+++ b/src/api/services/v3/cmp/CitService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await CitService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/cit/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/cit/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -14,7 +14,7 @@ test('get calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await CitService.get('cit-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/cit/cit-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/cit/cit-id/')
 })
 
 test('create calls the correct endpoint', async () => {
@@ -26,7 +26,7 @@ test('create calls the correct endpoint', async () => {
     action: '/worldPortal'
   }
   await CitService.create(mockCitTest)
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/cit/', mockCitTest)
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/cit/', mockCitTest)
 })
 
 test('update calls the correct endpoint', async () => {
@@ -35,11 +35,11 @@ test('update calls the correct endpoint', async () => {
   })
   const mockCitTest = { action: '/biggerWorld' }
   await CitService.update('cit-id', mockCitTest)
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/cit/cit-id/', mockCitTest)
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/cit/cit-id/', mockCitTest)
 })
 
 test('delete calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
   await CitService.delete('cit-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/cit/cit-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/cit/cit-id/')
 })

--- a/src/api/services/v3/cmp/CustomFormsService.js
+++ b/src/api/services/v3/cmp/CustomFormsService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/customForms'
+const URL = 'api/v3/cmp/customForms'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/CustomFormsService.test.js
+++ b/src/api/services/v3/cmp/CustomFormsService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await CustomFormsService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/customForms/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/customForms/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -14,7 +14,7 @@ test('get calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await CustomFormsService.get('customForm-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/customForms/customForm-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/customForms/customForm-id/')
 })
 
 test('submit order calls the correct endpoint', async () => {
@@ -27,7 +27,7 @@ test('submit order calls the correct endpoint', async () => {
   }
   await CustomFormsService.submitOrder('customForm-id', mockCustomFormOrder)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/customForms/customForm-id/submit/',
+    '/api/v3/cmp/customForms/customForm-id/submit/',
     mockCustomFormOrder
   )
 })
@@ -35,5 +35,5 @@ test('submit order calls the correct endpoint', async () => {
 test('delete calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
   await CustomFormsService.delete('customForm-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/customForms/customForm-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/customForms/customForm-id/')
 })

--- a/src/api/services/v3/cmp/DataTableSettingsService.js
+++ b/src/api/services/v3/cmp/DataTableSettingsService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/datatables/settings'
+const URL = 'api/v3/cmp/datatables/settings'
 
 export default {
   /**
@@ -16,7 +16,6 @@ export default {
    * @returns {Promise} resolves with a cloudbolt API Response object of the DataTableSettings object
    */
   get: (id) => crud.getItemById(URL, id),
-
 
   /**
    * Create a new DataTableSettings

--- a/src/api/services/v3/cmp/DataTableSettingsService.test.js
+++ b/src/api/services/v3/cmp/DataTableSettingsService.test.js
@@ -2,64 +2,77 @@ import { baseApi } from '../../../baseApi'
 import DataTableSettingsService from './DataTableSettingsService'
 
 test('list calls the correct endpoint', async () => {
-    const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({
-        data: { hello: 'world' }
-    })
-    await DataTableSettingsService.list()
-    expect(mockFn).toHaveBeenCalledWith('/v3/cmp/datatables/settings/')
+  const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({
+    data: { hello: 'world' }
+  })
+  await DataTableSettingsService.list()
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/datatables/settings/')
 })
 
 test('get calls the correct endpoint', async () => {
-    const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({
-        data: { hello: 'world' }
-    })
-    await DataTableSettingsService.get('dataTableSetting-id')
-    expect(mockFn).toHaveBeenCalledWith('/v3/cmp/datatables/settings/dataTableSetting-id/')
+  const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({
+    data: { hello: 'world' }
+  })
+  await DataTableSettingsService.get('dataTableSetting-id')
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/datatables/settings/dataTableSetting-id/'
+  )
 })
 
 test('create calls the correct endpoint', async () => {
-    const mockFn = jest.spyOn(baseApi, 'post').mockResolvedValue({
-        data: { hello: 'world' }
-    })
-    const mockDataTableSetting = {
-       dataTableType: 'mockType',
-       name: 'Mock Data Table Setting',
-    }
-    await DataTableSettingsService.create(mockDataTableSetting)
-    expect(mockFn).toHaveBeenCalledWith('/v3/cmp/datatables/settings/', mockDataTableSetting)
+  const mockFn = jest.spyOn(baseApi, 'post').mockResolvedValue({
+    data: { hello: 'world' }
+  })
+  const mockDataTableSetting = {
+    dataTableType: 'mockType',
+    name: 'Mock Data Table Setting'
+  }
+  await DataTableSettingsService.create(mockDataTableSetting)
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/datatables/settings/',
+    mockDataTableSetting
+  )
 })
 
 test('replace calls the correct endpoint', async () => {
-    const mockFn = jest.spyOn(baseApi, 'put').mockResolvedValue({
-        data: { hello: 'world' }
-    })
-    const mockDataTableSetting = {
-        dataTableType: 'mockType',
-        name: 'Mock Data Table Setting',
-    }
-    await DataTableSettingsService.replace('dataTableSetting-id', mockDataTableSetting)
-    expect(mockFn).toHaveBeenCalledWith(
-        '/v3/cmp/datatables/settings/dataTableSetting-id/',
-        mockDataTableSetting
-    )
+  const mockFn = jest.spyOn(baseApi, 'put').mockResolvedValue({
+    data: { hello: 'world' }
+  })
+  const mockDataTableSetting = {
+    dataTableType: 'mockType',
+    name: 'Mock Data Table Setting'
+  }
+  await DataTableSettingsService.replace(
+    'dataTableSetting-id',
+    mockDataTableSetting
+  )
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/datatables/settings/dataTableSetting-id/',
+    mockDataTableSetting
+  )
 })
 
 test('update calls the correct endpoint', async () => {
-    const mockFn = jest.spyOn(baseApi, 'patch').mockResolvedValue({
-        data: { hello: 'world' }
-    })
-    const mockDataTableSetting = {
-        name: 'Updated Mock Data Table Type',
-    }
-    await DataTableSettingsService.update('dataTableSetting-id', mockDataTableSetting)
-    expect(mockFn).toHaveBeenCalledWith(
-        '/v3/cmp/datatables/settings/dataTableSetting-id/',
-        mockDataTableSetting
-    )
+  const mockFn = jest.spyOn(baseApi, 'patch').mockResolvedValue({
+    data: { hello: 'world' }
+  })
+  const mockDataTableSetting = {
+    name: 'Updated Mock Data Table Type'
+  }
+  await DataTableSettingsService.update(
+    'dataTableSetting-id',
+    mockDataTableSetting
+  )
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/datatables/settings/dataTableSetting-id/',
+    mockDataTableSetting
+  )
 })
 
 test('delete calls the correct endpoint', async () => {
-    const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
-    await DataTableSettingsService.delete('dataTableSetting-id')
-    expect(mockFn).toHaveBeenCalledWith('/v3/cmp/datatables/settings/dataTableSetting-id/')
+  const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
+  await DataTableSettingsService.delete('dataTableSetting-id')
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/datatables/settings/dataTableSetting-id/'
+  )
 })

--- a/src/api/services/v3/cmp/DataTableTypesService.js
+++ b/src/api/services/v3/cmp/DataTableTypesService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/datatables/types'
+const URL = 'api/v3/cmp/datatables/types'
 
 export default {
   /**
@@ -16,7 +16,6 @@ export default {
    * @returns {Promise} resolves with a cloudbolt API Response object of the DataTableType object
    */
   get: (id) => crud.getItemById(URL, id),
-
 
   /**
    * Create a new DataTableType

--- a/src/api/services/v3/cmp/DataTableTypesService.test.js
+++ b/src/api/services/v3/cmp/DataTableTypesService.test.js
@@ -2,64 +2,71 @@ import { baseApi } from '../../../baseApi'
 import DataTableTypesService from './DataTableTypesService'
 
 test('list calls the correct endpoint', async () => {
-    const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({
-        data: { hello: 'world' }
-    })
-    await DataTableTypesService.list()
-    expect(mockFn).toHaveBeenCalledWith('/v3/cmp/datatables/types/')
+  const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({
+    data: { hello: 'world' }
+  })
+  await DataTableTypesService.list()
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/datatables/types/')
 })
 
 test('get calls the correct endpoint', async () => {
-    const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({
-        data: { hello: 'world' }
-    })
-    await DataTableTypesService.get('dataTableType-id')
-    expect(mockFn).toHaveBeenCalledWith('/v3/cmp/datatables/types/dataTableType-id/')
+  const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({
+    data: { hello: 'world' }
+  })
+  await DataTableTypesService.get('dataTableType-id')
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/datatables/types/dataTableType-id/'
+  )
 })
 
 test('create calls the correct endpoint', async () => {
-    const mockFn = jest.spyOn(baseApi, 'post').mockResolvedValue({
-        data: { hello: 'world' }
-    })
-    const mockDataTableType = {
-       dataModel: 'resources.models.ResourcesStructured',
-       name: 'Mock Data Table Type',
-    }
-    await DataTableTypesService.create(mockDataTableType)
-    expect(mockFn).toHaveBeenCalledWith('/v3/cmp/datatables/types/', mockDataTableType)
+  const mockFn = jest.spyOn(baseApi, 'post').mockResolvedValue({
+    data: { hello: 'world' }
+  })
+  const mockDataTableType = {
+    dataModel: 'resources.models.ResourcesStructured',
+    name: 'Mock Data Table Type'
+  }
+  await DataTableTypesService.create(mockDataTableType)
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/datatables/types/',
+    mockDataTableType
+  )
 })
 
 test('replace calls the correct endpoint', async () => {
-    const mockFn = jest.spyOn(baseApi, 'put').mockResolvedValue({
-        data: { hello: 'world' }
-    })
-    const mockDataTableType = {
-        dataModel: 'resources.models.ResourcesStructured',
-        name: 'Mock Data Table Type',
-    }
-    await DataTableTypesService.replace('dataTableType-id', mockDataTableType)
-    expect(mockFn).toHaveBeenCalledWith(
-        '/v3/cmp/datatables/types/dataTableType-id/',
-        mockDataTableType
-    )
+  const mockFn = jest.spyOn(baseApi, 'put').mockResolvedValue({
+    data: { hello: 'world' }
+  })
+  const mockDataTableType = {
+    dataModel: 'resources.models.ResourcesStructured',
+    name: 'Mock Data Table Type'
+  }
+  await DataTableTypesService.replace('dataTableType-id', mockDataTableType)
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/datatables/types/dataTableType-id/',
+    mockDataTableType
+  )
 })
 
 test('update calls the correct endpoint', async () => {
-    const mockFn = jest.spyOn(baseApi, 'patch').mockResolvedValue({
-        data: { hello: 'world' }
-    })
-    const mockDataTableType = {
-        name: 'Updated Mock Data Table Type',
-    }
-    await DataTableTypesService.update('dataTableType-id', mockDataTableType)
-    expect(mockFn).toHaveBeenCalledWith(
-        '/v3/cmp/datatables/types/dataTableType-id/',
-        mockDataTableType
-    )
+  const mockFn = jest.spyOn(baseApi, 'patch').mockResolvedValue({
+    data: { hello: 'world' }
+  })
+  const mockDataTableType = {
+    name: 'Updated Mock Data Table Type'
+  }
+  await DataTableTypesService.update('dataTableType-id', mockDataTableType)
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/datatables/types/dataTableType-id/',
+    mockDataTableType
+  )
 })
 
 test('delete calls the correct endpoint', async () => {
-    const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
-    await DataTableTypesService.delete('dataTableType-id')
-    expect(mockFn).toHaveBeenCalledWith('/v3/cmp/datatables/types/dataTableType-id/')
+  const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
+  await DataTableTypesService.delete('dataTableType-id')
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/datatables/types/dataTableType-id/'
+  )
 })

--- a/src/api/services/v3/cmp/EnvironmentsService.js
+++ b/src/api/services/v3/cmp/EnvironmentsService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/environments'
+const URL = 'api/v3/cmp/environments'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/EnvironmentsService.test.js
+++ b/src/api/services/v3/cmp/EnvironmentsService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await EnvironmentsService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/environments/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/environments/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -14,7 +14,9 @@ test('get calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await EnvironmentsService.get('environments-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/environments/environments-id/')
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/environments/environments-id/'
+  )
 })
 
 test('create calls the correct endpoint', async () => {
@@ -25,7 +27,10 @@ test('create calls the correct endpoint', async () => {
     name: 'worldEnvironment'
   }
   await EnvironmentsService.create(mockEnvironment)
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/environments/', mockEnvironment)
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/environments/',
+    mockEnvironment
+  )
 })
 
 test('update calls the correct endpoint', async () => {
@@ -35,7 +40,7 @@ test('update calls the correct endpoint', async () => {
   const mockEnvironment = { name: 'biggerWorldEnvironment' }
   await EnvironmentsService.update('environments-id', mockEnvironment)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/environments/environments-id/',
+    '/api/v3/cmp/environments/environments-id/',
     mockEnvironment
   )
 })
@@ -49,7 +54,7 @@ test('replace calls the correct endpoint', async () => {
   }
   await EnvironmentsService.replace('environments-id', mockEnvironment)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/environments/environments-id/',
+    '/api/v3/cmp/environments/environments-id/',
     mockEnvironment
   )
 })
@@ -57,7 +62,9 @@ test('replace calls the correct endpoint', async () => {
 test('delete calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
   await EnvironmentsService.delete('environments-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/environments/environments-id/')
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/environments/environments-id/'
+  )
 })
 
 test('export calls the correct endpoint', async () => {
@@ -71,7 +78,7 @@ test('export calls the correct endpoint', async () => {
   await EnvironmentsService.export('environments-id')
 
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/environments/environments-id/export/',
+    '/api/v3/cmp/environments/environments-id/export/',
     {},
     { responseType: 'blob' }
   )
@@ -91,7 +98,7 @@ test('export with optional params calls the correct endpoint', async () => {
   await EnvironmentsService.export('environments-id', mockEnvironmentOptions)
 
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/environments/environments-id/export/',
+    '/api/v3/cmp/environments/environments-id/export/',
     mockEnvironmentOptions,
     { responseType: 'blob' }
   )
@@ -103,7 +110,7 @@ test('getTechParameters calls the correct endpoint', async () => {
   })
   await EnvironmentsService.getTechParameters('environments-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/environments/environments-id/techSpecificParameters/'
+    '/api/v3/cmp/environments/environments-id/techSpecificParameters/'
   )
 })
 
@@ -114,7 +121,7 @@ test('refreshTechParameters calls the correct endpoint', async () => {
 
   await EnvironmentsService.refreshTechParameters('environments-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/environments/environments-id/techSpecificParameters:refresh/',
+    '/api/v3/cmp/environments/environments-id/techSpecificParameters:refresh/',
     undefined
   )
 })
@@ -125,7 +132,7 @@ test('getNetworks calls the correct endpoint', async () => {
   })
   await EnvironmentsService.getNetworks('environments-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/environments/environments-id/networks/'
+    '/api/v3/cmp/environments/environments-id/networks/'
   )
 })
 
@@ -140,7 +147,7 @@ test('setNetworks calls the correct endpoint', async () => {
 
   await EnvironmentsService.setNetworks('environments-id', mockNetwork)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/environments/environments-id/networks/',
+    '/api/v3/cmp/environments/environments-id/networks/',
     mockNetwork
   )
 })
@@ -151,7 +158,7 @@ test('getParameters calls the correct endpoint', async () => {
   })
   await EnvironmentsService.getParameters('environments-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/environments/environments-id/parameters/'
+    '/api/v3/cmp/environments/environments-id/parameters/'
   )
 })
 
@@ -169,7 +176,7 @@ test('setParameters calls the correct endpoint', async () => {
 
   await EnvironmentsService.setParameters('environments-id', mockParameters)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/environments/environments-id/parameters/',
+    '/api/v3/cmp/environments/environments-id/parameters/',
     mockParameters
   )
 })

--- a/src/api/services/v3/cmp/EulaService.js
+++ b/src/api/services/v3/cmp/EulaService.js
@@ -5,11 +5,11 @@ export default {
    * Gets the EULA information for the requesting user
    * @returns
    */
-  getEulaInfo: async () => await crud.getItemByEndpoint('v3/cmp/eula'),
+  getEulaInfo: async () => await crud.getItemByEndpoint('api/v3/cmp/eula'),
   /**
    * Updates the EULA acceptance information for the requesting user
    * @returns
    */
   updateEulaInfo: async (payload) =>
-    await crud.updateItemByEndpoint('v3/cmp/eula', payload)
+    await crud.updateItemByEndpoint('api/v3/cmp/eula', payload)
 }

--- a/src/api/services/v3/cmp/EulaService.test.js
+++ b/src/api/services/v3/cmp/EulaService.test.js
@@ -1,7 +1,7 @@
 import crud from '../../../crudOperations'
 import EulaService from './EulaService'
 
-const EULA_URL = 'v3/cmp/eula'
+const EULA_URL = 'api/v3/cmp/eula'
 
 describe('EulaService', () => {
   it('getEulaInfo calls crud.getItemByEndpoint and returns result', async () => {

--- a/src/api/services/v3/cmp/GroupsService.js
+++ b/src/api/services/v3/cmp/GroupsService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/groups'
+const URL = 'api/v3/cmp/groups'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/GroupsService.test.js
+++ b/src/api/services/v3/cmp/GroupsService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: [{ hello: 'world' }]
   })
   await GroupsService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/groups/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/groups/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -14,7 +14,7 @@ test('get calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await GroupsService.get('group-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/groups/group-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/groups/group-id/')
 })
 
 test('create calls the correct endpoint', async () => {
@@ -23,7 +23,7 @@ test('create calls the correct endpoint', async () => {
   })
   const mockGroup = { hello: 'world' }
   await GroupsService.create(mockGroup)
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/groups/', mockGroup)
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/groups/', mockGroup)
 })
 
 test('update calls the correct endpoint', async () => {
@@ -32,11 +32,11 @@ test('update calls the correct endpoint', async () => {
   })
   const mockGroup = { hello: 'world' }
   await GroupsService.update('group-id', mockGroup)
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/groups/group-id/', mockGroup)
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/groups/group-id/', mockGroup)
 })
 
 test('delete calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
   await GroupsService.delete('group-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/groups/group-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/groups/group-id/')
 })

--- a/src/api/services/v3/cmp/HistoriesService.js
+++ b/src/api/services/v3/cmp/HistoriesService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/histories'
+const URL = 'api/v3/cmp/histories'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/HistoriesService.test.js
+++ b/src/api/services/v3/cmp/HistoriesService.test.js
@@ -127,7 +127,7 @@ test('list calls the correct endpoint', async () => {
     data: [{ hello: 'world' }]
   })
   await HistoriesService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/histories/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/histories/')
 })
 
 test('list parses data without issue', async () => {
@@ -143,7 +143,7 @@ test('get calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await HistoriesService.get('history-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/histories/history-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/histories/history-id/')
 })
 
 test('get parses data without issue', async () => {

--- a/src/api/services/v3/cmp/InboundWebHookService.js
+++ b/src/api/services/v3/cmp/InboundWebHookService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/inboundWebHooks'
+const URL = 'api/v3/cmp/inboundWebHooks'
 
 export default {
   /**
@@ -34,8 +34,7 @@ export default {
    * @param {object} payload Inbound Web Hook object definition
    * @returns {Promise} resolves with a cloudbolt API Run Inbound Web Hook Success Response
    */
-  runPost: (id, payload) =>
-    crud.postItem(`${URL}/${id}/run`, payload),
+  runPost: (id, payload) => crud.postItem(`${URL}/${id}/run`, payload),
 
   /**
    * Run an Inbound Web Hook via GET
@@ -43,6 +42,5 @@ export default {
    * @param {object} options querystring name value pairs to be used as Action input values
    * @returns {Promise} resolves with a cloudbolt API Run Inbound Web Hook Success Response
    */
-  runGet: (id, options) =>
-    crud.getItemByEndpoint(`${URL}/${id}/run`, options),
+  runGet: (id, options) => crud.getItemByEndpoint(`${URL}/${id}/run`, options)
 }

--- a/src/api/services/v3/cmp/InboundWebHookService.test.js
+++ b/src/api/services/v3/cmp/InboundWebHookService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await InboundWebHook.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/inboundWebHooks/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/inboundWebHooks/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -14,7 +14,9 @@ test('get calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await InboundWebHook.get('inboundWebHook-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/inboundWebHooks/inboundWebHook-id/')
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/inboundWebHooks/inboundWebHook-id/'
+  )
 })
 
 test('export calls the correct endpoint', async () => {
@@ -27,7 +29,7 @@ test('export calls the correct endpoint', async () => {
 
   await InboundWebHook.export('inboundWebHook-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/inboundWebHooks/inboundWebHook-id/export/',
+    '/api/v3/cmp/inboundWebHooks/inboundWebHook-id/export/',
     {},
     { responseType: 'blob' }
   )
@@ -46,7 +48,7 @@ test('export with options calls the correct endpoint', async () => {
   }
   await InboundWebHook.export('inboundWebHook-id', mockinboundWebHookOptions)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/inboundWebHooks/inboundWebHook-id/export/',
+    '/api/v3/cmp/inboundWebHooks/inboundWebHook-id/export/',
     mockinboundWebHookOptions,
     { responseType: 'blob' }
   )
@@ -57,11 +59,11 @@ test('run calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   const mockParameters = {
-      param1: 'value1'
-  }   
+    param1: 'value1'
+  }
   await InboundWebHook.runGet('inboundWebHook-id', mockParameters)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/inboundWebHooks/inboundWebHook-id/run/?param1=value1',
+    '/api/v3/cmp/inboundWebHooks/inboundWebHook-id/run/?param1=value1'
   )
 })
 
@@ -70,11 +72,11 @@ test('run calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   const mockPayload = {
-      param1: 'value1'
+    param1: 'value1'
   }
   await InboundWebHook.runPost('inboundWebHook-id', mockPayload)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/inboundWebHooks/inboundWebHook-id/run/',
+    '/api/v3/cmp/inboundWebHooks/inboundWebHook-id/run/',
     mockPayload
   )
 })

--- a/src/api/services/v3/cmp/JobsService.js
+++ b/src/api/services/v3/cmp/JobsService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/jobs'
+const URL = 'api/v3/cmp/jobs'
 
 export default {
   /**
@@ -16,7 +16,7 @@ export default {
    * @param {array} payload.jobs List of Job hrefs to clone
    * @returns {Promise} resolves with a cloudbolt API Response object of Job objects
    */
-  cancel: (payload) => crud.postItem(URL+'/cancel', payload),
+  cancel: (payload) => crud.postItem(URL + '/cancel', payload),
 
   /**
    * Retrieve an existing job

--- a/src/api/services/v3/cmp/JobsService.test.js
+++ b/src/api/services/v3/cmp/JobsService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: [{ hello: 'world' }]
   })
   await JobsService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/jobs/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/jobs/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -14,24 +14,24 @@ test('get calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await JobsService.get('job-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/jobs/job-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/jobs/job-id/')
 })
 
 test('cancel calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'post').mockResolvedValue()
 
   const payload = {
-    jobs: ['/v3/cmp/jobs/job-id/']
+    jobs: ['/api/v3/cmp/jobs/job-id/']
   }
   await JobsService.cancel(payload)
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/jobs/cancel/', payload)
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/jobs/cancel/', payload)
 })
 
 test('clone calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'post').mockResolvedValue()
 
   await JobsService.clone('job-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/jobs/job-id/clone/', null)
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/jobs/job-id/clone/', null)
 })
 
 test('resume calls the correct endpoint', async () => {
@@ -40,5 +40,8 @@ test('resume calls the correct endpoint', async () => {
     resume_type: 'STEP'
   }
   await JobsService.resume('job-id', payload)
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/jobs/job-id/resume/', payload)
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/jobs/job-id/resume/',
+    payload
+  )
 })

--- a/src/api/services/v3/cmp/LicensingService.js
+++ b/src/api/services/v3/cmp/LicensingService.js
@@ -9,7 +9,7 @@ export default {
    */
   getLicenses: async (options) => {
     const result = await crud.getItems(
-      'v3/cmp/productLicenses',
+      'api/v3/cmp/productLicenses',
       options ? options : RETRIEVE_ALL_DATA_AND_SORT_BY_NAME
     )
     return result?.items
@@ -20,5 +20,5 @@ export default {
    * @returns
    */
   getLicensingStatus: async () =>
-    await crud.getItemByEndpoint('v3/cmp/productLicenses/status')
+    await crud.getItemByEndpoint('api/v3/cmp/productLicenses/status')
 }

--- a/src/api/services/v3/cmp/LicensingService.test.js
+++ b/src/api/services/v3/cmp/LicensingService.test.js
@@ -2,8 +2,8 @@ import crud from '../../../crudOperations'
 import { RETRIEVE_ALL_DATA_AND_SORT_BY_NAME } from '../../../helpers/RestOptionsBuilder'
 import LicensingService from './LicensingService'
 
-const GET_LICENSES_URL = 'v3/cmp/productLicenses'
-const GET_LICENSING_STATUS_URL = 'v3/cmp/productLicenses/status'
+const GET_LICENSES_URL = 'api/v3/cmp/productLicenses'
+const GET_LICENSING_STATUS_URL = 'api/v3/cmp/productLicenses/status'
 
 describe('LicensingService', () => {
   it('getLicenses calls getItems and returns items if in response', async () => {

--- a/src/api/services/v3/cmp/LoggingService.js
+++ b/src/api/services/v3/cmp/LoggingService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/logs'
+const URL = 'api/v3/cmp/logs'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/LoggingService.test.js
+++ b/src/api/services/v3/cmp/LoggingService.test.js
@@ -8,7 +8,7 @@ test('getApplicationLog calls the correct endpoint for zipfile', async () => {
   const mockLogZipOptions = true
 
   await LoggingService.getApplicationLog(mockLogZipOptions)
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/logs/application/?zip=true')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/logs/application/?zip=true')
 })
 
 test('getApplicationLog calls the correct endpoint', async () => {
@@ -17,7 +17,7 @@ test('getApplicationLog calls the correct endpoint', async () => {
   })
 
   await LoggingService.getApplicationLog()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/logs/application/?zip=false')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/logs/application/?zip=false')
 })
 
 test('getWebLog calls the correct endpoint', async () => {
@@ -26,7 +26,7 @@ test('getWebLog calls the correct endpoint', async () => {
   })
 
   await LoggingService.getWebLog()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/logs/web/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/logs/web/')
 })
 
 test('getSupportBundleLog calls the correct endpoint', async () => {
@@ -35,6 +35,6 @@ test('getSupportBundleLog calls the correct endpoint', async () => {
   })
 
   await LoggingService.getSupportBundleLog()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/logs/supportBundle/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/logs/supportBundle/')
 })
 // Not actually checking/getting zipfile

--- a/src/api/services/v3/cmp/MiscellaneousSettingsService.js
+++ b/src/api/services/v3/cmp/MiscellaneousSettingsService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/miscellaneousSettings'
+const URL = 'api/v3/cmp/miscellaneousSettings'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/MiscellaneousSettingsService.test.js
+++ b/src/api/services/v3/cmp/MiscellaneousSettingsService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await MiscellaneousSettingsService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/miscellaneousSettings/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/miscellaneousSettings/')
 })
 
 test('update calls the correct endpoint', async () => {
@@ -16,7 +16,7 @@ test('update calls the correct endpoint', async () => {
   const mockMiscSettings = { defaultUserDisplayScheme: 'world' }
   await MiscellaneousSettingsService.update(mockMiscSettings)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/miscellaneousSettings/',
+    '/api/v3/cmp/miscellaneousSettings/',
     mockMiscSettings
   )
 })

--- a/src/api/services/v3/cmp/OrdersService.js
+++ b/src/api/services/v3/cmp/OrdersService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/orders'
+const URL = 'api/v3/cmp/orders'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/OrdersService.test.js
+++ b/src/api/services/v3/cmp/OrdersService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await OrdersService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/orders/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/orders/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -14,7 +14,7 @@ test('get calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await OrdersService.get('order-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/orders/order-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/orders/order-id/')
 })
 
 test('duplicate calls the correct endpoint', async () => {
@@ -24,7 +24,7 @@ test('duplicate calls the correct endpoint', async () => {
 
   await OrdersService.duplicate('order-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/orders/order-id/duplicate/',
+    '/api/v3/cmp/orders/order-id/duplicate/',
     undefined
   )
 })
@@ -36,7 +36,7 @@ test('approve calls the correct endpoint', async () => {
 
   await OrdersService.approve('order-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/orders/order-id/approve/',
+    '/api/v3/cmp/orders/order-id/approve/',
     undefined
   )
 })
@@ -51,7 +51,7 @@ test('deny calls the correct endpoint', async () => {
 
   await OrdersService.deny('order-id', mockDenyOrderDetail)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/orders/order-id/deny/',
+    '/api/v3/cmp/orders/order-id/deny/',
     mockDenyOrderDetail
   )
 })
@@ -63,7 +63,7 @@ test('submit calls the correct endpoint', async () => {
 
   await OrdersService.submit('order-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/orders/order-id/submit/',
+    '/api/v3/cmp/orders/order-id/submit/',
     undefined
   )
 })
@@ -75,7 +75,7 @@ test('cancel calls the correct endpoint', async () => {
 
   await OrdersService.cancel('order-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/orders/order-id/cancel/',
+    '/api/v3/cmp/orders/order-id/cancel/',
     undefined
   )
 })
@@ -87,7 +87,7 @@ test('clear calls the correct endpoint', async () => {
 
   await OrdersService.clear('order-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/orders/order-id/clear/',
+    '/api/v3/cmp/orders/order-id/clear/',
     undefined
   )
 })

--- a/src/api/services/v3/cmp/OsBuildsService.js
+++ b/src/api/services/v3/cmp/OsBuildsService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/osBuilds'
+const URL = 'api/v3/cmp/osBuilds'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/OsBuildsService.test.js
+++ b/src/api/services/v3/cmp/OsBuildsService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await OsBuildsService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/osBuilds/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/osBuilds/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -14,7 +14,7 @@ test('get calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await OsBuildsService.get('osBuild-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/osBuilds/osBuild-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/osBuilds/osBuild-id/')
 })
 
 test('create calls the correct endpoint', async () => {
@@ -23,7 +23,7 @@ test('create calls the correct endpoint', async () => {
   })
   const mockOsBuild = { name: 'world' }
   await OsBuildsService.create(mockOsBuild)
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/osBuilds/', mockOsBuild)
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/osBuilds/', mockOsBuild)
 })
 
 test('update calls the correct endpoint', async () => {
@@ -33,7 +33,7 @@ test('update calls the correct endpoint', async () => {
   const mockOsBuild = { hello: 'world' }
   await OsBuildsService.update('osBuild-id', mockOsBuild)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/osBuilds/osBuild-id/',
+    '/api/v3/cmp/osBuilds/osBuild-id/',
     mockOsBuild
   )
 })
@@ -45,7 +45,7 @@ test('replace calls the correct endpoint', async () => {
   const mockOsBuild = { hello: 'world' }
   await OsBuildsService.replace('osBuild-id', mockOsBuild)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/osBuilds/osBuild-id/',
+    '/api/v3/cmp/osBuilds/osBuild-id/',
     mockOsBuild
   )
 })
@@ -53,5 +53,5 @@ test('replace calls the correct endpoint', async () => {
 test('delete calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
   await OsBuildsService.delete('osBuild-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/osBuilds/osBuild-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/osBuilds/osBuild-id/')
 })

--- a/src/api/services/v3/cmp/ParametersService.js
+++ b/src/api/services/v3/cmp/ParametersService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/parameters'
+const URL = 'api/v3/cmp/parameters'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/ParametersService.test.js
+++ b/src/api/services/v3/cmp/ParametersService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await ParametersService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/parameters/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/parameters/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -14,7 +14,7 @@ test('get calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await ParametersService.get('parameter-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/parameters/parameter-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/parameters/parameter-id/')
 })
 
 test('create calls the correct endpoint', async () => {
@@ -27,7 +27,7 @@ test('create calls the correct endpoint', async () => {
     type: 'world'
   }
   await ParametersService.create(mockParameters)
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/parameters/', mockParameters)
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/parameters/', mockParameters)
 })
 
 test('update calls the correct endpoint', async () => {
@@ -37,7 +37,7 @@ test('update calls the correct endpoint', async () => {
   const mockParameters = { name: 'biggerWorld' }
   await ParametersService.update('parameter-id', mockParameters)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/parameters/parameter-id/',
+    '/api/v3/cmp/parameters/parameter-id/',
     mockParameters
   )
 })
@@ -53,7 +53,7 @@ test('replace calls the correct endpoint', async () => {
   }
   await ParametersService.replace('parameter-id', mockParameters)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/parameters/parameter-id/',
+    '/api/v3/cmp/parameters/parameter-id/',
     mockParameters
   )
 })
@@ -61,5 +61,5 @@ test('replace calls the correct endpoint', async () => {
 test('delete calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
   await ParametersService.delete('parameter-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/parameters/parameter-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/parameters/parameter-id/')
 })

--- a/src/api/services/v3/cmp/PermissionsService.js
+++ b/src/api/services/v3/cmp/PermissionsService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/permissions'
+const URL = 'api/v3/cmp/permissions'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/PermissionsService.test.js
+++ b/src/api/services/v3/cmp/PermissionsService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await PermissionsService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/permissions/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/permissions/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -14,5 +14,5 @@ test('get calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await PermissionsService.get('permission-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/permissions/permission-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/permissions/permission-id/')
 })

--- a/src/api/services/v3/cmp/ProductInfoService.js
+++ b/src/api/services/v3/cmp/ProductInfoService.js
@@ -5,5 +5,6 @@ export default {
    * Gets the product info (version) currently being used
    * @returns
    */
-  getProductInfo: async () => await crud.getItemByEndpoint('v3/cmp/productInfo')
+  getProductInfo: async () =>
+    await crud.getItemByEndpoint('api/v3/cmp/productInfo')
 }

--- a/src/api/services/v3/cmp/ProductInfoService.test.js
+++ b/src/api/services/v3/cmp/ProductInfoService.test.js
@@ -1,7 +1,7 @@
 import crud from '../../../crudOperations'
 import ProductInfoService from './ProductInfoService'
 
-const PRODUCT_INFO_URL = 'v3/cmp/productInfo'
+const PRODUCT_INFO_URL = 'api/v3/cmp/productInfo'
 
 describe('ProductInfoService', () => {
   it('getProductInfo calls crud.getItemByEndpoint and returns result', async () => {

--- a/src/api/services/v3/cmp/ProductLicensesService.js
+++ b/src/api/services/v3/cmp/ProductLicensesService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/productLicenses'
+const URL = 'api/v3/cmp/productLicenses'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/ProductLicensesService.test.js
+++ b/src/api/services/v3/cmp/ProductLicensesService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: [{ hello: 'world' }]
   })
   await ProductLicensesService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/productLicenses/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/productLicenses/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -15,7 +15,7 @@ test('get calls the correct endpoint', async () => {
   })
   await ProductLicensesService.get('productLicense-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/productLicenses/productLicense-id/'
+    '/api/v3/cmp/productLicenses/productLicense-id/'
   )
 })
 
@@ -26,7 +26,7 @@ test('add calls the correct endpoint', async () => {
   const mockProductLicense = { licenseText: 'world' }
   await ProductLicensesService.add(mockProductLicense)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/productLicenses/',
+    '/api/v3/cmp/productLicenses/',
     mockProductLicense
   )
 })
@@ -37,13 +37,13 @@ test('status calls the correct endpoint', async () => {
   })
 
   await ProductLicensesService.status()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/productLicenses/status/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/productLicenses/status/')
 })
 
 test('delete calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
   await ProductLicensesService.delete('productLicense-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/productLicenses/productLicense-id/'
+    '/api/v3/cmp/productLicenses/productLicense-id/'
   )
 })

--- a/src/api/services/v3/cmp/RatesServices/ApplicationRatesService.js
+++ b/src/api/services/v3/cmp/RatesServices/ApplicationRatesService.js
@@ -1,6 +1,6 @@
 import crud from '../../../../crudOperations'
 
-const URL = 'v3/cmp/rates/applicationRates'
+const URL = 'api/v3/cmp/rates/applicationRates'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/RatesServices/ApplicationRatesService.test.js
+++ b/src/api/services/v3/cmp/RatesServices/ApplicationRatesService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await ApplicationRatesService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/rates/applicationRates/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/rates/applicationRates/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -15,7 +15,7 @@ test('get calls the correct endpoint', async () => {
   })
   await ApplicationRatesService.get('applicationRate-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/rates/applicationRates/applicationRate-id/'
+    '/api/v3/cmp/rates/applicationRates/applicationRate-id/'
   )
 })
 
@@ -29,7 +29,7 @@ test('create calls the correct endpoint', async () => {
   }
   await ApplicationRatesService.create(mockApplicationRate)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/rates/applicationRates/',
+    '/api/v3/cmp/rates/applicationRates/',
     mockApplicationRate
   )
 })
@@ -44,7 +44,7 @@ test('update calls the correct endpoint', async () => {
     mockApplicationRate
   )
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/rates/applicationRates/applicationRate-id/',
+    '/api/v3/cmp/rates/applicationRates/applicationRate-id/',
     mockApplicationRate
   )
 })
@@ -53,6 +53,6 @@ test('delete calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
   await ApplicationRatesService.delete('applicationRate-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/rates/applicationRates/applicationRate-id/'
+    '/api/v3/cmp/rates/applicationRates/applicationRate-id/'
   )
 })

--- a/src/api/services/v3/cmp/RatesServices/OsBuildRatesService.js
+++ b/src/api/services/v3/cmp/RatesServices/OsBuildRatesService.js
@@ -1,6 +1,6 @@
 import crud from '../../../../crudOperations'
 
-const URL = 'v3/cmp/rates/osBuildRates'
+const URL = 'api/v3/cmp/rates/osBuildRates'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/RatesServices/OsBuildRatesService.test.js
+++ b/src/api/services/v3/cmp/RatesServices/OsBuildRatesService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await OsBuildRatesService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/rates/osBuildRates/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/rates/osBuildRates/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -15,7 +15,7 @@ test('get calls the correct endpoint', async () => {
   })
   await OsBuildRatesService.get('osBuildRate-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/rates/osBuildRates/osBuildRate-id/'
+    '/api/v3/cmp/rates/osBuildRates/osBuildRate-id/'
   )
 })
 
@@ -29,7 +29,7 @@ test('create calls the correct endpoint', async () => {
   }
   await OsBuildRatesService.create(mockOsBuildRate)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/rates/osBuildRates/',
+    '/api/v3/cmp/rates/osBuildRates/',
     mockOsBuildRate
   )
 })
@@ -41,7 +41,7 @@ test('update calls the correct endpoint', async () => {
   const mockOsBuildRate = { rate: 'biggerWorld' }
   await OsBuildRatesService.update('osBuildRate-id', mockOsBuildRate)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/rates/osBuildRates/osBuildRate-id/',
+    '/api/v3/cmp/rates/osBuildRates/osBuildRate-id/',
     mockOsBuildRate
   )
 })
@@ -50,6 +50,6 @@ test('delete calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
   await OsBuildRatesService.delete('osBuildRate-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/rates/osBuildRates/osBuildRate-id/'
+    '/api/v3/cmp/rates/osBuildRates/osBuildRate-id/'
   )
 })

--- a/src/api/services/v3/cmp/RatesServices/ParameterRatesService.js
+++ b/src/api/services/v3/cmp/RatesServices/ParameterRatesService.js
@@ -1,6 +1,6 @@
 import crud from '../../../../crudOperations'
 
-const URL = 'v3/cmp/rates/parameterRates'
+const URL = 'api/v3/cmp/rates/parameterRates'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/RatesServices/ParameterRatesService.test.js
+++ b/src/api/services/v3/cmp/RatesServices/ParameterRatesService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await ParameterRatesService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/rates/parameterRates/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/rates/parameterRates/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -15,7 +15,7 @@ test('get calls the correct endpoint', async () => {
   })
   await ParameterRatesService.get('parameterRate-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/rates/parameterRates/parameterRate-id/'
+    '/api/v3/cmp/rates/parameterRates/parameterRate-id/'
   )
 })
 
@@ -29,7 +29,7 @@ test('create calls the correct endpoint', async () => {
   }
   await ParameterRatesService.create(mockParameterRate)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/rates/parameterRates/',
+    '/api/v3/cmp/rates/parameterRates/',
     mockParameterRate
   )
 })
@@ -41,7 +41,7 @@ test('update calls the correct endpoint', async () => {
   const mockParameterRate = { rate: 'biggerWorld' }
   await ParameterRatesService.update('parameterRate-id', mockParameterRate)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/rates/parameterRates/parameterRate-id/',
+    '/api/v3/cmp/rates/parameterRates/parameterRate-id/',
     mockParameterRate
   )
 })
@@ -50,6 +50,6 @@ test('delete calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
   await ParameterRatesService.delete('parameterRate-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/rates/parameterRates/parameterRate-id/'
+    '/api/v3/cmp/rates/parameterRates/parameterRate-id/'
   )
 })

--- a/src/api/services/v3/cmp/RatesServices/RateSettingsService.js
+++ b/src/api/services/v3/cmp/RatesServices/RateSettingsService.js
@@ -1,6 +1,6 @@
 import crud from '../../../../crudOperations'
 
-const URL = 'v3/cmp/rates/settings'
+const URL = 'api/v3/cmp/rates/settings'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/RatesServices/RateSettingsService.test.js
+++ b/src/api/services/v3/cmp/RatesServices/RateSettingsService.test.js
@@ -6,7 +6,7 @@ test('get calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await RateSettingsService.get()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/rates/settings/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/rates/settings/')
 })
 
 test('update calls the correct endpoint', async () => {
@@ -19,7 +19,7 @@ test('update calls the correct endpoint', async () => {
   }
   await RateSettingsService.update(mockRatesSettings)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/rates/settings/',
+    '/api/v3/cmp/rates/settings/',
     mockRatesSettings
   )
 })

--- a/src/api/services/v3/cmp/ResourceActionsService.js
+++ b/src/api/services/v3/cmp/ResourceActionsService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/resourceActions'
+const URL = 'api/v3/cmp/resourceActions'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/ResourceActionsService.test.js
+++ b/src/api/services/v3/cmp/ResourceActionsService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await ResourceActionsService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/resourceActions/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/resourceActions/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -15,7 +15,7 @@ test('get calls the correct endpoint', async () => {
   })
   await ResourceActionsService.get('resourceAction-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/resourceActions/resourceAction-id/'
+    '/api/v3/cmp/resourceActions/resourceAction-id/'
   )
 })
 
@@ -28,7 +28,7 @@ test('create calls the correct endpoint', async () => {
   }
   await ResourceActionsService.create(mockResourceAction)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/resourceActions/',
+    '/api/v3/cmp/resourceActions/',
     mockResourceAction
   )
 })
@@ -43,7 +43,7 @@ test('export calls the correct endpoint', async () => {
 
   await ResourceActionsService.export('resourceAction-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/resourceActions/resourceAction-id/export/',
+    '/api/v3/cmp/resourceActions/resourceAction-id/export/',
     {},
     { responseType: 'blob' }
   )
@@ -65,7 +65,7 @@ test('export with options calls the correct endpoint', async () => {
     mockResourceActionsOptions
   )
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/resourceActions/resourceAction-id/export/',
+    '/api/v3/cmp/resourceActions/resourceAction-id/export/',
     mockResourceActionsOptions,
     { responseType: 'blob' }
   )
@@ -83,7 +83,7 @@ test('run calls the correct endpoint', async () => {
   }
   await ResourceActionsService.run('resourceAction-id', mockResourceAction)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/resourceActions/resourceAction-id/runAction/',
+    '/api/v3/cmp/resourceActions/resourceAction-id/runAction/',
     mockResourceAction
   )
 })
@@ -100,7 +100,7 @@ test('run calls the synchronous endpoint', async () => {
   }
   await ResourceActionsService.runSync('resourceAction-id', mockResourceAction)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/resourceActions/resourceAction-id/runActionSync/',
+    '/api/v3/cmp/resourceActions/resourceAction-id/runActionSync/',
     mockResourceAction
   )
 })

--- a/src/api/services/v3/cmp/ResourceHandlersService.js
+++ b/src/api/services/v3/cmp/ResourceHandlersService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/resourceHandlers'
+const URL = 'api/v3/cmp/resourceHandlers'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/ResourceHandlersService.test.js
+++ b/src/api/services/v3/cmp/ResourceHandlersService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await ResourceHandlersService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/resourceHandlers/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/resourceHandlers/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -15,6 +15,6 @@ test('get calls the correct endpoint', async () => {
   })
   await ResourceHandlersService.get('resourceHandler-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/resourceHandlers/resourceHandler-id/'
+    '/api/v3/cmp/resourceHandlers/resourceHandler-id/'
   )
 })

--- a/src/api/services/v3/cmp/ResourceTypesService.js
+++ b/src/api/services/v3/cmp/ResourceTypesService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/resourceTypes'
+const URL = 'api/v3/cmp/resourceTypes'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/ResourceTypesService.test.js
+++ b/src/api/services/v3/cmp/ResourceTypesService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await ResourceTypesService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/resourceTypes/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/resourceTypes/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -14,7 +14,9 @@ test('get calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await ResourceTypesService.get('resourceType-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/resourceTypes/resourceType-id/')
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/resourceTypes/resourceType-id/'
+  )
 })
 
 test('create calls the correct endpoint', async () => {
@@ -27,7 +29,7 @@ test('create calls the correct endpoint', async () => {
   }
   await ResourceTypesService.create(mockResourceType)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/resourceTypes/',
+    '/api/v3/cmp/resourceTypes/',
     mockResourceType
   )
 })
@@ -39,7 +41,7 @@ test('update calls the correct endpoint', async () => {
   const mockResourceType = { name: 'biggerWorld' }
   await ResourceTypesService.update('resourceType-id', mockResourceType)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/resourceTypes/resourceType-id/',
+    '/api/v3/cmp/resourceTypes/resourceType-id/',
     mockResourceType
   )
 })
@@ -47,5 +49,7 @@ test('update calls the correct endpoint', async () => {
 test('delete calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
   await ResourceTypesService.delete('resourceType-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/resourceTypes/resourceType-id/')
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/resourceTypes/resourceType-id/'
+  )
 })

--- a/src/api/services/v3/cmp/ResourcesService.js
+++ b/src/api/services/v3/cmp/ResourcesService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/resources'
+const URL = 'api/v3/cmp/resources'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/ResourcesService.test.js
+++ b/src/api/services/v3/cmp/ResourcesService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await ResourcesService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/resources/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/resources/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -14,5 +14,5 @@ test('get calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await ResourcesService.get('resource-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/resources/resource-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/resources/resource-id/')
 })

--- a/src/api/services/v3/cmp/ResourcesStructuredService.js
+++ b/src/api/services/v3/cmp/ResourcesStructuredService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/resourcesStructured'
+const URL = 'api/v3/cmp/resourcesStructured'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/ResourcesStructuredService.test.js
+++ b/src/api/services/v3/cmp/ResourcesStructuredService.test.js
@@ -1,7 +1,7 @@
 import { baseApi } from '../../../baseApi'
 import ResourcesStructuredService from './ResourcesStructuredService'
 
-const RESOURCES_STRUCTURED_ENDPOINT = '/v3/cmp/resourcesStructured/'
+const RESOURCES_STRUCTURED_ENDPOINT = '/api/v3/cmp/resourcesStructured/'
 
 test('list calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({

--- a/src/api/services/v3/cmp/RolesService.js
+++ b/src/api/services/v3/cmp/RolesService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/roles'
+const URL = 'api/v3/cmp/roles'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/RolesService.test.js
+++ b/src/api/services/v3/cmp/RolesService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await RolesService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/roles/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/roles/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -14,7 +14,7 @@ test('get calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await RolesService.get('role-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/roles/role-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/roles/role-id/')
 })
 
 test('create calls the correct endpoint', async () => {
@@ -26,7 +26,7 @@ test('create calls the correct endpoint', async () => {
     name: 'worldName'
   }
   await RolesService.create(mockRole)
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/roles/', mockRole)
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/roles/', mockRole)
 })
 
 test('update calls the correct endpoint', async () => {
@@ -35,7 +35,7 @@ test('update calls the correct endpoint', async () => {
   })
   const mockRole = { hello: 'world' }
   await RolesService.update('role-id', mockRole)
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/roles/role-id/', mockRole)
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/roles/role-id/', mockRole)
 })
 
 test('replace calls the correct endpoint', async () => {
@@ -44,11 +44,11 @@ test('replace calls the correct endpoint', async () => {
   })
   const mockRole = { hello: 'world' }
   await RolesService.replace('role-id', mockRole)
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/roles/role-id/', mockRole)
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/roles/role-id/', mockRole)
 })
 
 test('delete calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
   await RolesService.delete('role-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/roles/role-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/roles/role-id/')
 })

--- a/src/api/services/v3/cmp/ServerActionsService.js
+++ b/src/api/services/v3/cmp/ServerActionsService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/serverActions'
+const URL = 'api/v3/cmp/serverActions'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/ServerActionsService.test.js
+++ b/src/api/services/v3/cmp/ServerActionsService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await ServerActionsService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/serverActions/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/serverActions/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -14,7 +14,9 @@ test('get calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await ServerActionsService.get('serverAction-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/serverActions/serverAction-id/')
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/serverActions/serverAction-id/'
+  )
 })
 
 test('create calls the correct endpoint', async () => {
@@ -26,7 +28,7 @@ test('create calls the correct endpoint', async () => {
   }
   await ServerActionsService.create(mockServerAction)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/serverActions/',
+    '/api/v3/cmp/serverActions/',
     mockServerAction
   )
 })
@@ -41,7 +43,7 @@ test('export calls the correct endpoint', async () => {
 
   await ServerActionsService.export('serverAction-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/serverActions/serverAction-id/export/',
+    '/api/v3/cmp/serverActions/serverAction-id/export/',
     {},
     { responseType: 'blob' }
   )
@@ -60,7 +62,7 @@ test('export with options calls the correct endpoint', async () => {
   }
   await ServerActionsService.export('serverAction-id', mockServerActionsOptions)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/serverActions/serverAction-id/export/',
+    '/api/v3/cmp/serverActions/serverAction-id/export/',
     mockServerActionsOptions,
     { responseType: 'blob' }
   )
@@ -78,7 +80,7 @@ test('run calls the correct endpoint', async () => {
   }
   await ServerActionsService.run('serverAction-id', mockServerAction)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/serverActions/serverAction-id/runAction/',
+    '/api/v3/cmp/serverActions/serverAction-id/runAction/',
     mockServerAction
   )
 })
@@ -95,7 +97,7 @@ test('run calls the synchronous endpoint', async () => {
   }
   await ServerActionsService.runSync('serverAction-id', mockServerAction)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/serverActions/serverAction-id/runActionSync/',
+    '/api/v3/cmp/serverActions/serverAction-id/runActionSync/',
     mockServerAction
   )
 })

--- a/src/api/services/v3/cmp/ServerService.js
+++ b/src/api/services/v3/cmp/ServerService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/servers'
+const URL = 'api/v3/cmp/servers'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/ServerService.test.js
+++ b/src/api/services/v3/cmp/ServerService.test.js
@@ -1,7 +1,7 @@
 import { baseApi } from '../../../baseApi'
 import ServerService from './ServerService'
 
-const URL = '/v3/cmp/servers/'
+const URL = '/api/v3/cmp/servers/'
 
 test('list calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({

--- a/src/api/services/v3/cmp/ServerSummaryService.js
+++ b/src/api/services/v3/cmp/ServerSummaryService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/serverSummary'
+const URL = 'api/v3/cmp/serverSummary'
 
 export default {
   /**
@@ -8,5 +8,5 @@ export default {
    * @param options anything parsable by URLSearchParams. See useful options here https://docs.cloudbolt.io/articles/#!cloudbolt-latest-docs/api-conventions/a/h2__904191799
    * @returns {Promise} resolves with a paginated list of existing Resource Types
    */
-  get: (options) => crud.getItemByEndpoint(URL, options),
+  get: (options) => crud.getItemByEndpoint(URL, options)
 }

--- a/src/api/services/v3/cmp/ServerSummaryService.test.js
+++ b/src/api/services/v3/cmp/ServerSummaryService.test.js
@@ -1,10 +1,10 @@
 import { baseApi } from '../../../baseApi'
-import ServerSummaryService from "./ServerSummaryService";
+import ServerSummaryService from './ServerSummaryService'
 
 test('get calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({
     data: { hello: 'world' }
   })
   await ServerSummaryService.get()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/serverSummary/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/serverSummary/')
 })

--- a/src/api/services/v3/cmp/SettingsService.js
+++ b/src/api/services/v3/cmp/SettingsService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/settings'
+const URL = 'api/v3/cmp/settings'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/SettingsService.test.js
+++ b/src/api/services/v3/cmp/SettingsService.test.js
@@ -4,7 +4,7 @@ import SettingsService from './SettingsService'
 test('settings calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({})
   await SettingsService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/settings/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/settings/')
 })
 
 test('settings list passes options correctly', async () => {
@@ -13,5 +13,7 @@ test('settings list passes options correctly', async () => {
     data: { runQuickSetup: 'true' }
   })
   await SettingsService.list(testOptions)
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/settings/?fields=runQuickSetup')
+  expect(mockFn).toHaveBeenCalledWith(
+    '/api/v3/cmp/settings/?fields=runQuickSetup'
+  )
 })

--- a/src/api/services/v3/cmp/SystemService.js
+++ b/src/api/services/v3/cmp/SystemService.js
@@ -1,7 +1,7 @@
 import crud from '../../../crudOperations'
 
-const statusURL = 'v3/cmp/system/status'
-const settingsURL = 'v3/cmp/system/settings'
+const statusURL = 'api/v3/cmp/system/status'
+const settingsURL = 'api/v3/cmp/system/settings'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/SystemService.test.js
+++ b/src/api/services/v3/cmp/SystemService.test.js
@@ -4,11 +4,11 @@ import SystemService from './SystemService'
 test('status calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({})
   await SystemService.status()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/system/status/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/system/status/')
 })
 
 test('settings calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({})
   await SystemService.settings()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/system/settings/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/system/settings/')
 })

--- a/src/api/services/v3/cmp/UiExtensionComponentsService.js
+++ b/src/api/services/v3/cmp/UiExtensionComponentsService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const URL = 'v3/cmp/uiExtensionComponents'
+const URL = 'api/v3/cmp/uiExtensionComponents'
 
 export default {
   /**

--- a/src/api/services/v3/cmp/UiExtensionComponentsService.test.js
+++ b/src/api/services/v3/cmp/UiExtensionComponentsService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     data: { hello: 'world' }
   })
   await UiExtensionComponentsService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/cmp/uiExtensionComponents/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/cmp/uiExtensionComponents/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -15,6 +15,6 @@ test('get calls the correct endpoint', async () => {
   })
   await UiExtensionComponentsService.get('uiExtensionComponent-id')
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/cmp/uiExtensionComponents/uiExtensionComponent-id/'
+    '/api/v3/cmp/uiExtensionComponents/uiExtensionComponent-id/'
   )
 })

--- a/src/api/services/v3/cmp/UserService.js
+++ b/src/api/services/v3/cmp/UserService.js
@@ -1,7 +1,7 @@
 import crud from '../../../crudOperations'
 import { camelCaseKeys } from '../../../helpers/textUtils'
 
-const URL = 'v3/cmp/users'
+const URL = 'api/v3/cmp/users'
 
 export default {
   /**
@@ -17,7 +17,7 @@ export default {
    * @returns {Promise<Object>} - the user's information
    */
   getCurrentUser: async (options = { includeCMPCatalogFields: true }) =>
-    await crud.getItemByEndpoint('v3/cmp/user', options),
+    await crud.getItemByEndpoint('api/v3/cmp/user', options),
 
   /**
    * Retrieves the cmp dashboard widgets for the specified user

--- a/src/api/services/v3/cmp/UserService.test.js
+++ b/src/api/services/v3/cmp/UserService.test.js
@@ -2,11 +2,11 @@ import { baseApi } from '../../../baseApi'
 import crud from '../../../crudOperations'
 import UserService from './UserService'
 
-const USERS_URL = 'v3/cmp/users'
-const USER_URL = 'v3/cmp/user'
-const WIDGETS_URL = 'v3/cmp/users/1/dashboardWidgets'
-const DASHBOARD_URL = 'v3/cmp/users/1/cuiDashboard'
-const USER_PERMISSION_URL = 'v3/cmp/users/1/permissions'
+const USERS_URL = 'api/v3/cmp/users'
+const USER_URL = 'api/v3/cmp/user'
+const WIDGETS_URL = 'api/v3/cmp/users/1/dashboardWidgets'
+const DASHBOARD_URL = 'api/v3/cmp/users/1/cuiDashboard'
+const USER_PERMISSION_URL = 'api/v3/cmp/users/1/permissions'
 
 const mockApiResponse = {
   _links: {

--- a/src/api/services/v3/dashboard/AnnouncementService.js
+++ b/src/api/services/v3/dashboard/AnnouncementService.js
@@ -1,6 +1,6 @@
 import crud from '../../../crudOperations'
 
-const BASE_URL = 'v3/dashboard/announcements'
+const BASE_URL = 'api/v3/dashboard/announcements'
 
 export default {
   /**

--- a/src/api/services/v3/dashboard/AnnouncementService.test.js
+++ b/src/api/services/v3/dashboard/AnnouncementService.test.js
@@ -1,7 +1,7 @@
 import { baseApi } from '../../../baseApi'
 import AnnouncementService from './AnnouncementService'
 
-const BASE_URL = '/v3/dashboard/announcements/'
+const BASE_URL = '/api/v3/dashboard/announcements/'
 
 test('list calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'get').mockResolvedValue({

--- a/src/api/services/v3/dashboard/DashboardService.js
+++ b/src/api/services/v3/dashboard/DashboardService.js
@@ -11,7 +11,7 @@ export default {
    * @returns {Promise} resolves with a cloudbolt API Response object of Blueprint objects
    */
   getBlueprints: (options) =>
-    crud.getItems('v3/dashboard/blueprints', { page_size: 12, ...options }),
+    crud.getItems('api/v3/dashboard/blueprints', { page_size: 12, ...options }),
 
   /**
    * Retrieve environments to display on the Environments Widget
@@ -19,14 +19,15 @@ export default {
    * @returns {Promise} resolves with a cloudbolt API Response object of Environment objects
    */
   getEnvironments: (options) =>
-    crud.getItems('v3/dashboard/environments', { ...options }),
+    crud.getItems('api/v3/dashboard/environments', { ...options }),
 
   /**
    * Retrieve events to display on the Events Widget
    * @param options anything parsable by URLSearchParams. See useful options here https://docs.cloudbolt.io/articles/#!cloudbolt-latest-docs/api-conventions/a/h2__904191799
    * @returns {Promise} resolves with a cloudbolt API Response object of Event objects
    */
-  getEvents: (options) => crud.getItems('v3/dashboard/events', { ...options }),
+  getEvents: (options) =>
+    crud.getItems('api/v3/dashboard/events', { ...options }),
 
   /**
    * Retrieve groups to display on the Groups Widget
@@ -34,7 +35,7 @@ export default {
    * @returns {Promise} resolves with a cloudbolt API Response object of Group objects
    */
   getGroups: (options) =>
-    crud.getItems('v3/dashboard/groups', { page_size: 100, ...options }),
+    crud.getItems('api/v3/dashboard/groups', { page_size: 100, ...options }),
 
   /**
    * Retrieve jobs to display on the Jobs Widget
@@ -42,7 +43,7 @@ export default {
    * @returns {Promise} resolves with a cloudbolt API Response object of Job objects
    */
   getJobs: (options) =>
-    crud.getItemByEndpoint('v3/dashboard/jobs', { ...options }),
+    crud.getItemByEndpoint('api/v3/dashboard/jobs', { ...options }),
 
   /**
    * Retrieve Orders to display on the Orders Widget
@@ -50,7 +51,7 @@ export default {
    * @returns {Promise} resolves with a cloudbolt API Response object of Order objects
    */
   getOrders: (options) =>
-    crud.getItems('v3/dashboard/orders', { page_size: 100, ...options }),
+    crud.getItems('api/v3/dashboard/orders', { page_size: 100, ...options }),
 
   /**
    * Retrieve reports to display on the Reports Widget
@@ -58,7 +59,7 @@ export default {
    * @returns {Promise} resolves with a cloudbolt API Response object of Report objects
    */
   getReports: (options) =>
-    crud.getItems('v3/dashboard/reports', { limit: 12, ...options }),
+    crud.getItems('api/v3/dashboard/reports', { limit: 12, ...options }),
 
   /**
    * Retrieve Servers to display on the Servers Widget
@@ -66,7 +67,7 @@ export default {
    * @returns {Promise} resolves with a cloudbolt API Response object of Server objects
    */
   getServers: (options) =>
-    crud.getItems('v3/dashboard/servers', { page_size: 20, ...options }),
+    crud.getItems('api/v3/dashboard/servers', { page_size: 20, ...options }),
 
   // Misc
 

--- a/src/api/services/v3/dashboard/WidgetService.js
+++ b/src/api/services/v3/dashboard/WidgetService.js
@@ -7,7 +7,7 @@ export default {
    * @param options anything parsable by URLSearchParams. See useful options here https://docs.cloudbolt.io/articles/#!cloudbolt-latest-docs/api-conventions/a/h2__904191799
    * @returns {Promise} resolves with a cloudbolt API Response object of Widget objects
    */
-  list: (options) => crud.getItems('v3/dashboard/widgets', options),
+  list: (options) => crud.getItems('api/v3/dashboard/widgets', options),
 
   /**
    * Retrieve a single widget and its customized permissions.
@@ -16,7 +16,8 @@ export default {
    * @param options anything parsable by URLSearchParams. See useful options here https://docs.cloudbolt.io/articles/#!cloudbolt-latest-docs/api-conventions/a/h2__904191799
    * @returns {Promise} resolves with a single widget objects
    */
-  get: (id, options) => crud.getItemById('v3/dashboard/widgets', id, options),
+  get: (id, options) =>
+    crud.getItemById('api/v3/dashboard/widgets', id, options),
 
   /**
    * Create a new widget with customized permissions.
@@ -24,7 +25,8 @@ export default {
    * @param {object} newWidget New Widget object
    * @returns {Promise} resolves with the created widget object
    */
-  create: (newWidget) => crud.createNewItem('v3/dashboard/widgets', newWidget),
+  create: (newWidget) =>
+    crud.createNewItem('api/v3/dashboard/widgets', newWidget),
 
   /**
    * Updates a widget with customized permissions.
@@ -34,7 +36,7 @@ export default {
    * @returns {Promise} resolves with the updated widget object
    */
   update: (id, updatedWidget) =>
-    crud.updateItemById('v3/dashboard/widgets', id, updatedWidget),
+    crud.updateItemById('api/v3/dashboard/widgets', id, updatedWidget),
 
   /**
    * Deletes a widget and its customized permissions.
@@ -42,11 +44,11 @@ export default {
    * @param {string} id or global_id
    * @returns {Promise} resolves with an object describing the deletion
    */
-  delete: (id) => crud.deleteItemById('v3/dashboard/widgets', id),
+  delete: (id) => crud.deleteItemById('api/v3/dashboard/widgets', id),
 
   /**
    * Retrieve an array of widgets the requesting user should not be able to see.
    * @returns {Promise<Array>} resolves with an array of objects
    */
-  blacklist: () => crud.getItemByEndpoint('v3/dashboard/widgets/blacklist')
+  blacklist: () => crud.getItemByEndpoint('api/v3/dashboard/widgets/blacklist')
 }

--- a/src/api/services/v3/dashboard/WidgetService.test.js
+++ b/src/api/services/v3/dashboard/WidgetService.test.js
@@ -6,7 +6,7 @@ test('list calls the correct endpoint', async () => {
     .spyOn(baseApi, 'get')
     .mockResolvedValue({ widgets: [{ hello: 'world' }] })
   await WidgetService.list()
-  expect(mockFn).toHaveBeenCalledWith('/v3/dashboard/widgets/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/dashboard/widgets/')
 })
 
 test('get calls the correct endpoint', async () => {
@@ -14,7 +14,7 @@ test('get calls the correct endpoint', async () => {
     .spyOn(baseApi, 'get')
     .mockResolvedValue({ widget: { hello: 'world' } })
   await WidgetService.get('widget-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/dashboard/widgets/widget-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/dashboard/widgets/widget-id/')
 })
 
 test('create calls the correct endpoint', async () => {
@@ -23,7 +23,7 @@ test('create calls the correct endpoint', async () => {
     .mockResolvedValue({ widget: { hello: 'world' } })
   const mockWidget = { hello: 'world' }
   await WidgetService.create(mockWidget)
-  expect(mockFn).toHaveBeenCalledWith('/v3/dashboard/widgets/', mockWidget)
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/dashboard/widgets/', mockWidget)
 })
 
 test('update calls the correct endpoint', async () => {
@@ -33,7 +33,7 @@ test('update calls the correct endpoint', async () => {
   const mockWidget = { hello: 'world' }
   await WidgetService.update('widget-id', mockWidget)
   expect(mockFn).toHaveBeenCalledWith(
-    '/v3/dashboard/widgets/widget-id/',
+    '/api/v3/dashboard/widgets/widget-id/',
     mockWidget
   )
 })
@@ -41,7 +41,7 @@ test('update calls the correct endpoint', async () => {
 test('delete calls the correct endpoint', async () => {
   const mockFn = jest.spyOn(baseApi, 'delete').mockResolvedValue({})
   await WidgetService.delete('widget-id')
-  expect(mockFn).toHaveBeenCalledWith('/v3/dashboard/widgets/widget-id/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/dashboard/widgets/widget-id/')
 })
 
 test('blacklist calls the correct endpoint', async () => {
@@ -49,5 +49,5 @@ test('blacklist calls the correct endpoint', async () => {
     .spyOn(baseApi, 'get')
     .mockResolvedValue([{ hello: 'world' }])
   await WidgetService.blacklist()
-  expect(mockFn).toHaveBeenCalledWith('/v3/dashboard/widgets/blacklist/')
+  expect(mockFn).toHaveBeenCalledWith('/api/v3/dashboard/widgets/blacklist/')
 })


### PR DESCRIPTION
Ticket - [CMP-32](https://cloudbolt.atlassian.net/browse/CMP-32)
Engineer @tropotorres 

Changing the `axios`  baseUrl from `/api` to just `/`
Tests all passing. Needs to pair with a similar PR on the CUI

[CMP-32]: https://cloudbolt.atlassian.net/browse/CMP-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ