### PR TITLE
Feature/cmp 800 passing options to current portal endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudbolt/js-sdk",
-  "version": "0.6.7-beta.0",
+  "version": "0.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudbolt/js-sdk",
-      "version": "0.6.7-beta.0",
+      "version": "0.6.7",
       "dependencies": {
         "axios": "^0.27.2",
         "ramda": "^0.28.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudbolt/js-sdk",
-  "version": "0.6.6",
+  "version": "0.6.7-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudbolt/js-sdk",
-      "version": "0.6.6",
+      "version": "0.6.7-beta.0",
       "dependencies": {
         "axios": "^0.27.2",
         "ramda": "^0.28.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudbolt/js-sdk",
-  "version": "0.6.7-beta.0",
+  "version": "0.6.7",
   "description": "CloudBolt Javascript package for interacting with the CloudBolt API",
   "scripts": {
     "husky:install": "husky install",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudbolt/js-sdk",
-  "version": "0.6.6",
+  "version": "0.6.7-beta.0",
   "description": "CloudBolt Javascript package for interacting with the CloudBolt API",
   "scripts": {
     "husky:install": "husky install",

--- a/src/api/services/v3/cmp/BrandedPortalsService.js
+++ b/src/api/services/v3/cmp/BrandedPortalsService.js
@@ -21,7 +21,7 @@ export default {
    * Retrieve the current or default BrandedPortal
    * @returns {Promise} resolves with a cloudbolt API Response object of the current BrandedPortal object
    */
-  getCurrentPortal: () => crud.getItemByEndpoint(`${URL}/currentPortal`),
+  getCurrentPortal: (options) => crud.getItemByEndpoint(`${URL}/currentPortal`, options),
 
   /**
    * Create a new BrandedPortal


### PR DESCRIPTION
CMP-800 | Added options inclusion support for brandedPortals/getCurrentPortal endpoint
